### PR TITLE
s3 object time based rollover

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,33 @@ $ bin/pulsar-admin sinks delete --name aws-s3-test
 "Deleted successfully"
 ```
 
+### Sink configuration
+AWS S3 configuration such as accessKeyId, secretAccessKey, region, and bucketname needs to be specifed in [the configuration yaml](./s3/config/pulsar-s3-io.yaml)
+
+When set `logLevel: "debug"`, debug logs will be printed by the sink.
+
+Pulsar messages under the same ledger ID are grouped under a single S3 Object file. S3 object file follows the naming convention prefix with the input topic with the ledger Id. All messages are under the same ledger Id are written this file.
+
+Since the sink uses the latest Pulsar message's ledger ID to detect the ledger rollover, a time based S3 Object rollover is also required to write the last ledger's messages into S3 in the case the messages over an topic are permanently stopped. `s3ObjectRolloverMinutes` in the config must be greater than `managedLedgerMaxLedgerRolloverTimeMinutes` set up in the Pulsar's broker.conf.
+
+Because of ledger Id is used to identify an S3 object, the sink currently only supports a single input topic.
+
+How Pulsar managed the ledger is configurable. Here are the default settings (from broker.conf):
+```
+# Max number of entries to append to a ledger before triggering a rollover
+# A ledger rollover is triggered on these conditions
+#  * Either the max rollover time has been reached
+#  * or max entries have been written to the ledged and at least min-time
+#    has passed
+managedLedgerMaxEntriesPerLedger=50000
+
+# Minimum time between ledger rollover for a topic
+managedLedgerMinLedgerRolloverTimeMinutes=10
+
+# Maximum time before forcing a ledger rollover for a topic
+managedLedgerMaxLedgerRolloverTimeMinutes=240
+```
+
 ### Topic schema registry
 It is mandatory a schema is enforced over the input topics. The Sink would have fatal error to create parquet format when it receives messages with different schemas.
 

--- a/s3/config/pulsar-s3-io.yaml
+++ b/s3/config/pulsar-s3-io.yaml
@@ -4,3 +4,5 @@ configs:
   awsregion: "us-east-2"
   bucketName: "bucket-name"
   partSize: 5242880
+  s3ObjectRolloverMinutes: 10
+  logLevel: "debug"

--- a/s3/src/main/java/com/kesque/pulsar/sink/s3/AWSS3Config.java
+++ b/s3/src/main/java/com/kesque/pulsar/sink/s3/AWSS3Config.java
@@ -65,13 +65,33 @@ public class AWSS3Config implements Serializable {
         this.secretAccessKey = secretKey;
     }
 
-    // support trigger types are ledger, time based, size based
-    private String triggerType = "ledger";
-    public String getTriggerType() {
-        return this.triggerType;
+    // a timer interval for s3 Object rollover in minutes
+    private int s3ObjectRolloverMinutes = 10;
+    public int getS3ObjectRolloverMinutes() {
+        return this.s3ObjectRolloverMinutes;
     }
-    public void setTriggerType(String triggerType) {
-        this.triggerType = triggerType;
+    public void setS3ObjectRolloverMinutes(int s3ObjectRolloverMinutes) {
+        if (s3ObjectRolloverMinutes>0) {
+            this.s3ObjectRolloverMinutes = s3ObjectRolloverMinutes;
+        }
+    }
+
+    private boolean isDebug = false;
+    public boolean debugLoglevel() {
+        return isDebug;
+    }
+
+    // currently only support debug level
+    private String logLevel = "";
+    public String getLogLevel() {
+        return this.logLevel;
+    }
+    /**
+     * @param logLevel the logLevel to set
+     */
+    public void setLogLevel(String logLevel) {
+        this.logLevel = logLevel;
+        this.isDebug = this.logLevel.equalsIgnoreCase("debug");
     }
 
     @FieldDoc(

--- a/s3/src/main/java/com/kesque/pulsar/sink/s3/Util.java
+++ b/s3/src/main/java/com/kesque/pulsar/sink/s3/Util.java
@@ -3,20 +3,21 @@ package com.kesque.pulsar.sink.s3;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Calendar;
 
 public class Util {
 
-    public static String ensureValidBucketName(String bucketName) {
-		String formatted = bucketName.replaceAll("\\s+","_");
+	public static String ensureValidBucketName(String bucketName) {
+		String formatted = bucketName.replaceAll("\\s+", "_");
 		int length = bucketName.length();
-		if(length >= 62)
+		if (length >= 62)
 			length = 62;
-		formatted = formatted.substring(0,length);
-		formatted = formatted.replace(".","d");
+		formatted = formatted.substring(0, length);
+		formatted = formatted.replace(".", "d");
 		formatted = formatted.toLowerCase();
-		if(formatted.endsWith("-"))
-			formatted = formatted.substring(0,length - 1);
-		
+		if (formatted.endsWith("-"))
+			formatted = formatted.substring(0, length - 1);
+
 		return formatted;
 	}
 
@@ -32,11 +33,19 @@ public class Util {
 
 	/**
 	 * Check if the current time is over the duration limite since the start.
+	 * 
 	 * @param start
 	 * @param limit
 	 * @return
 	 */
 	public static boolean isOver(Instant start, Duration limit) {
 		return Duration.between(start, Instant.now()).compareTo(limit) > 0;
+	}
+
+	/**
+	 * Get the current time in millieseconds.
+	 */
+	public static long getNowMilli() {
+		return Calendar.getInstance().getTimeInMillis();
 	}
 }

--- a/s3/src/main/java/com/kesque/pulsar/sink/s3/format/RecordWriter.java
+++ b/s3/src/main/java/com/kesque/pulsar/sink/s3/format/RecordWriter.java
@@ -21,9 +21,8 @@ public interface RecordWriter extends Closeable {
     void close();
 
     /**
-     * Flush writer's data and commit the records in Kafka. Optionally, this operation might also
+     * Flush writer's data and commit the records in Pulsar. Optionally, this operation might also
      * close the writer.
      */
     void commit();
-    
 }


### PR DESCRIPTION
Add time based rollover for AWS S3 object.
Add limitation only support a single input topic since we use ledger Id to identify with S3 object.